### PR TITLE
fix: remove stale package export entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,17 +21,9 @@
       "require": "./dist/nuxt.js",
       "import": "./dist/nuxt.mjs"
     },
-    "./resolvers": {
-      "require": "./dist/resolvers.js",
-      "import": "./dist/resolvers.mjs"
-    },
     "./rollup": {
       "require": "./dist/rollup.js",
       "import": "./dist/rollup.mjs"
-    },
-    "./types": {
-      "require": "./dist/types.js",
-      "import": "./dist/types.mjs"
     },
     "./vite": {
       "require": "./dist/vite.js",


### PR DESCRIPTION
## Summary

Removes the stale `./resolvers` and `./types` package export entries. The published package does not include the corresponding `dist/resolvers.*` or `dist/types.*` files, so those public subpaths currently resolve to missing files.

## Reproduction

From a clean project with the published package:

```bash
npm init -y
npm install unplugin-imagemin@0.7.0
node --input-type=module -e "import('unplugin-imagemin/resolvers').catch(e => { console.error(e.code, e.message); process.exit(2) })"
node --input-type=module -e "import('unplugin-imagemin/types').catch(e => { console.error(e.code, e.message); process.exit(2) })"
```

Both fail with `ERR_MODULE_NOT_FOUND` because the export map points at missing files:

- `dist/resolvers.mjs`
- `dist/types.mjs`

## Verification

I checked the published tarball with:

```bash
npm pack unplugin-imagemin@0.7.0 --dry-run --json
```

The package includes the concrete entrypoints for `index`, `nuxt`, `rollup`, `vite`, `webpack`, and `esbuild`, but it does not include `dist/resolvers.*` or `dist/types.*`.

After this change, every non-wildcard concrete path left in `exports` points to a file that exists in the published tarball.

Note: I also tried `pnpm run build` locally. The JS build emitted the expected entries, but the DTS step failed on an existing unrelated type error in `src/core/utils.ts` (`Argument of type 'string' is not assignable to parameter of type 'never'`). This PR only changes package metadata.
